### PR TITLE
fix: Guard against conn leak after server close

### DIFF
--- a/server_test.go
+++ b/server_test.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"testing"
 	"time"
+
+	gossh "golang.org/x/crypto/ssh"
 )
 
 func TestAddHostKey(t *testing.T) {
@@ -123,4 +125,105 @@ func TestServerClose(t *testing.T) {
 		<-clientDoneChan
 		return
 	}
+}
+
+func TestServerClose_ConnectionLeak(t *testing.T) {
+	l := newLocalListener()
+	s := &Server{
+		Handler: func(s Session) {
+			time.Sleep(5 * time.Second)
+		},
+	}
+	go func() {
+		err := s.Serve(l)
+		if err != nil && err != ErrServerClosed {
+			t.Error(err)
+		}
+	}()
+
+	clientDoneChan := make(chan struct{})
+	closeDoneChan := make(chan struct{})
+
+	num := 3
+	ch := make(chan struct{}, num)
+	go func() {
+		for i := 0; i < num; i++ {
+			<-ch
+		}
+		close(clientDoneChan)
+	}()
+	prepare := make(chan struct{}, num)
+	go func() {
+		for i := 0; i < num; i++ {
+			go func() {
+				defer func() {
+					ch <- struct{}{}
+				}()
+				sess, _, cleanup, err := newClientSession2(t, l.Addr().String(), nil)
+				prepare <- struct{}{}
+				if err != nil {
+					t.Log(err)
+					return
+				}
+				defer cleanup()
+				if err := sess.Run(""); err != nil && err != io.EOF {
+					t.Log(err)
+				}
+			}()
+		}
+	}()
+
+	go func() {
+		for i := 0; i < num-1; i++ {
+			<-prepare
+		}
+		err := s.Close()
+		if err != nil {
+			t.Error(err)
+		}
+		close(closeDoneChan)
+	}()
+
+	timeout := time.After(1000 * time.Millisecond)
+	select {
+	case <-timeout:
+		t.Error("timeout")
+		return
+	case <-closeDoneChan:
+	}
+	select {
+	case <-timeout:
+		t.Error("timeout")
+		return
+	case <-clientDoneChan:
+	}
+}
+
+func newClientSession2(t *testing.T, addr string, config *gossh.ClientConfig) (*gossh.Session, *gossh.Client, func(), error) {
+	t.Helper()
+
+	if config == nil {
+		config = &gossh.ClientConfig{
+			User: "testuser",
+			Auth: []gossh.AuthMethod{
+				gossh.Password("testpass"),
+			},
+		}
+	}
+	if config.HostKeyCallback == nil {
+		config.HostKeyCallback = gossh.InsecureIgnoreHostKey()
+	}
+	client, err := gossh.Dial("tcp", addr, config)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	session, err := client.NewSession()
+	if err != nil {
+		client.Close()
+		return nil, nil, nil, err
+	}
+	return session, client, func() {
+		session.Close()
+		client.Close()
+	}, nil
 }

--- a/session_test.go
+++ b/session_test.go
@@ -230,9 +230,9 @@ func TestPty(t *testing.T) {
 
 func TestPtyResize(t *testing.T) {
 	t.Parallel()
-	winch0 := Window{40, 80}
-	winch1 := Window{80, 160}
-	winch2 := Window{20, 40}
+	winch0 := Window{Width: 40, Height: 80}
+	winch1 := Window{Width: 80, Height: 160}
+	winch2 := Window{Width: 20, Height: 40}
 	winches := make(chan Window)
 	done := make(chan bool)
 	session, _, cleanup := newTestSession(t, &Server{


### PR DESCRIPTION
Noticed this leak as part of https://github.com/coder/coder/pull/7004

See: https://github.com/coder/coder/actions/runs/4609297757/jobs/8146257114?pr=7004

**NOTE:** This is mainly a problem when using `Serve`, which we were not previously using in coder. However, our previous implementation of starting multiple goroutines for each connection were not ideal either. This fix + usage of Serve should reduce overhead/memory usage when there are many connections.

We will also be looking to refactor the implementation as part of https://github.com/coder/coder/issues/6177.
