### PR TITLE
feat: adds callback call when connection ends

### DIFF
--- a/ssh.go
+++ b/ssh.go
@@ -71,6 +71,14 @@ type ServerConfigCallback func(ctx Context) *gossh.ServerConfig
 // Please note: the net.Conn is likely to be closed at this point
 type ConnectionFailedCallback func(conn net.Conn, err error)
 
+// ConnectionCompleteCallback is a hook for reporting connections that
+// complete.  The included error is from the underlying SSH transport
+// protocol mux (golang.org/x/crypto/ssh), and is non-nil, even for
+// normal termination.
+//
+// Please note: the ServerConn is closed at this point
+type ConnectionCompleteCallback func(conn *gossh.ServerConn, err error)
+
 // Window represents the size of a PTY window.
 //
 // See https://datatracker.ietf.org/doc/html/rfc4254#section-6.2


### PR DESCRIPTION
I want to add logging to the Coder Agent when ssh connections disconnect, including the reason for disconnection.  c.f. https://github.com/coder/coder/issues/7961

Currently, our ssh library doesn't expose or log this information, as it only calls the ConnectionFailedCallback if the connection fails during the initial SSH handshake, not if it fails later.

This PR makes it so that if the initial ssh handshake succeeds, then we start a goroutine that waits for the connection to end, and calls the callback.  We already log calls to this callback in our server code, but in a separate PR we might want to adjust so that we only log at Info or Debug for "expected" disconnection errors like EOF.