### PR TITLE
fix: avoid data race in session signal channel register/deregister

### DIFF
--- a/session.go
+++ b/session.go
@@ -263,7 +263,9 @@ func (sess *session) Signals(c chan<- Signal) {
 		// and sigBuf. We also guarantee that calling Signals(ch)
 		// followed by Signals(nil) will have depleted the sigBuf when
 		// the second call returns and that there will be no more
-		// signals on ch.
+		// signals on ch. This is done in a goroutine so we can return
+		// early and allow the caller to set up processing for the
+		// channel even after calling Signals(ch).
 		defer sess.sigMu.Unlock()
 		for _, sig := range sess.sigBuf {
 			sess.sigCh <- sig


### PR DESCRIPTION
We recently added signal support to `agentssh`, however, I noticed the following goleak flake today:

```
=== Failed
=== FAIL: agent/agentssh  (0.00s)
PASS
goleak: Errors on successful test run: found unexpected goroutines:
[Goroutine 228 in state chan send (nil chan), with github.com/gliderlabs/ssh.(*session).Signals.func1 on top of the stack:
goroutine 228 [chan send (nil chan)]:
github.com/gliderlabs/ssh.(*session).Signals.func1()
	/home/runner/go/pkg/mod/github.com/coder/ssh@v0.0.0-20230621095435-9a7e23486f1c/session.go:256 +0xcf
created by github.com/gliderlabs/ssh.(*session).Signals
	/home/runner/go/pkg/mod/github.com/coder/ssh@v0.0.0-20230621095435-9a7e23486f1c/session.go:254 +0x176
]
FAIL	github.com/coder/coder/v2/agent/agentssh	1.870s

DONE 5618 tests, 48 skipped, 1 failure in 230.997s
Error: Process completed with exit code 1.
```

https://github.com/coder/coder/actions/runs/7003589751/job/19049631559?pr=10883

This made me take a closer look at the implementation and saw that it was racy. This PR fixes the race.
